### PR TITLE
Replace old unmaintained notification dependency with native browser API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 First install dependencies:
 
 ```bash
-npm install --force
+npm install
 ```
 
 Next, run the development server:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "react-dom": "^18",
         "react-ga4": "^2.1.0",
         "react-microsoft-clarity": "^1.2.0",
-        "react-push-notification": "^1.5.3",
         "react-search-autocomplete": "^8.5.2",
         "react-timer-hook": "^3.0.7",
         "react-use-audio-player": "^2.2.0",
@@ -4664,14 +4663,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/react-microsoft-clarity/-/react-microsoft-clarity-1.2.0.tgz",
       "integrity": "sha512-a1bsJR1uN1daWq3cBc7NheEGPXrotMRE0oFeRio7kXvHawzQfqu5iX9BoYFF9zRUL0dn+Mz57h1fNlcv3pqXEg=="
-    },
-    "node_modules/react-push-notification": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/react-push-notification/-/react-push-notification-1.5.4.tgz",
-      "integrity": "sha512-ZsiJfz8dNvfz0ClKcrzaKojIAdYou+s2N2M4Z6EuAlQlBsVqex/Wv0hldgueSLKihmGbZouj/oPih/gy5xlKIQ==",
-      "peerDependencies": {
-        "react": "^16.8.0"
-      }
     },
     "node_modules/react-search-autocomplete": {
       "version": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-dom": "^18",
     "react-ga4": "^2.1.0",
     "react-microsoft-clarity": "^1.2.0",
-    "react-push-notification": "^1.5.3",
     "react-search-autocomplete": "^8.5.2",
     "react-timer-hook": "^3.0.7",
     "react-use-audio-player": "^2.2.0",

--- a/src/app/farming/Timer.tsx
+++ b/src/app/farming/Timer.tsx
@@ -4,7 +4,6 @@ import { memo, useState, useEffect } from "react";
 import { useTimer } from "react-timer-hook";
 import { useGlobalAudioPlayer } from "react-use-audio-player";
 import useLocalStorage from "use-local-storage";
-import addNotification from "react-push-notification";
 
 const Timer = ({ duration, setDuration }) => {
   const [loopAlarm, setLoopAlarm] = useLocalStorage("loopAlarm", false);
@@ -53,13 +52,10 @@ const Timer = ({ duration, setDuration }) => {
       console.warn("Timer Finished");
       setFinished(true);
       play();
-      addNotification({
-        title: "FAPI Timer Finished",
-        // subtitle: 'This is a subtitle',
-        // message: 'This is a very long message',
-        // theme: 'darkblue',
-        native: true, // when using native, your OS will handle theming.
-      });
+
+      if (Notification.permission === 'granted') {
+        new Notification("FAPI Timer Finished");
+      }
     },
   });
 
@@ -215,6 +211,12 @@ const Timer = ({ duration, setDuration }) => {
         {/* start */}
         <button
           onClick={(e) => {
+            // We have to request Notification permission in response to a user gesture
+            if (Notification.permission === "default") {
+              // only requests if they haven't already granted/denied permission
+              void Notification.requestPermission(); // doesn't matter if the user grants or not
+            }
+
             if (finished) {
               let time = new Date();
               time = new Date(time.getTime() + timeIncrease);
@@ -247,6 +249,12 @@ const Timer = ({ duration, setDuration }) => {
         {/* <button onClick={resume}>Resume</button> */}
         <button
           onClick={() => {
+            // We have to request Notification permission in response to a user gesture
+            if (Notification.permission === "default") {
+              // only requests if they haven't already granted/denied permission
+              void Notification.requestPermission(); // doesn't matter if the user grants or not
+            }
+
             // Restarts to 5 minutes timer
             // const time = new Date();
             // time.setSeconds(time.getSeconds() + 300);


### PR DESCRIPTION
[react-push-notification](https://www.npmjs.com/package/react-push-notification) is an old library with a npm peer dependency on React 16. That causes issues since the project depends on React 18 requiring the flag --legacy-peer-deps to override this requirement when running `npm install`.

The library, in addition to the above problem, has a much broader scope than what is required by the project. It is only used to show a native notification for which there is a widely supported browser API.

Finally, there was a third problem with the way permission to show notifications was requested. These days it can only be requested in response to a direct user interaction (like a click handler). Since this request was made by the library as it is trying to show the notification, and the library is called by the timer finishing. This is not in response to a user action so the browser will not prompt the end user for notification permission.