### PR TITLE
Optimize the calculations for required reincarnation XP for a given level

### DIFF
--- a/src/app/cards/page_content.tsx
+++ b/src/app/cards/page_content.tsx
@@ -72,6 +72,9 @@ import {
     cardMapImg, cardLabelImg, defaultWeights, CARD_DISPLAY_IDS, permPowerBonusFormula, tempPowerBonusFormula, powerFormula, cardIDMap, maxKey
 } from '../util/cardMapping';
 
+
+let reincLevelRequirements = {};
+
 interface CardCardProps {
     vertical,
     displayMode,
@@ -1115,6 +1118,13 @@ const CalcReinc = function (data, reincCardCharges?: any) {
     while (loopFlag) {
 
         let required = calculateRequiredReincarnationXP(futureReincLevel);
+        if (reincLevelRequirements[futureReincLevel]) {
+            required = reincLevelRequirements[futureReincLevel];
+        }
+        else {
+            required = calculateRequiredReincarnationXP(futureReincLevel);
+            reincLevelRequirements[futureReincLevel] = required;
+        }
         if (currentReincExp.greaterThan(required)) {
             futureReincLevel++;
             currentReincExp = mathHelper.subtractDecimal(currentReincExp, required);

--- a/src/app/cards/page_content.tsx
+++ b/src/app/cards/page_content.tsx
@@ -1104,18 +1104,17 @@ const CalcReinc = function (data, reincCardCharges?: any) {
     let temp1 = mathHelper.multiplyDecimal(timerBonuses, otherBonuses)
 
     let currentReincExp = mathHelper.multiplyDecimal(mathHelper.multiplyDecimal(mathHelper.multiplyDecimal(classTotal, temp1), waves), confection);
-    let requiredReincExp = mathHelper.createDecimal(data.ReincarnationExpRequiredBD);
     let currentReincLevel = mathHelper.createDecimal(data.ReincarnationLevel).toNumber();
-    let calcedReincExp = reincHelper.calcRequiredReincExp(currentReincLevel, data)
     let requiredReincLevel = data.AscensionReincLevelRequired;
     let currReincTime = data.CurrentReincarnationTimer / (60 * 60);
 
+    let calculateRequiredReincarnationXP = reincHelper.calcRequiredReincExp(data);
 
     let futureReincLevel = currentReincLevel;
     let loopFlag = true;
     while (loopFlag) {
 
-        let required = reincHelper.calcRequiredReincExp(futureReincLevel, data);
+        let required = calculateRequiredReincarnationXP(futureReincLevel);
         if (currentReincExp.greaterThan(required)) {
             futureReincLevel++;
             currentReincExp = mathHelper.subtractDecimal(currentReincExp, required);

--- a/src/app/util/reincHelper.ts
+++ b/src/app/util/reincHelper.ts
@@ -27,20 +27,7 @@ import mathHelper from './math';
 // );dsadsddasds
 
 const helper = {
-    calcRequiredReincExp: function (currLevel: number, data) {
-        let step1 = 5 + currLevel * 5;
-        let temp1 = mathHelper.max(0.0, currLevel / 500000.0);
-        let step2 = mathHelper.min(1.0025, mathHelper.addDecimal(1.00005, temp1));
-        let step3 = mathHelper.min(currLevel, 3000.0);
-
-        let finalStep1 = mathHelper.multiplyDecimal(step1, mathHelper.pow(step2, step3));
-
-        let step4Cont = mathHelper.pow(1.001, mathHelper.max(currLevel - 3000, 0.0));
-        let step5 = mathHelper.addDecimal(1, mathHelper.max(0.0, mathHelper.min(1.0, (currLevel - 1500) / 1000)));
-
-        let inner1 = mathHelper.multiplyDecimal(finalStep1, step4Cont);
-        let finalStep2 = mathHelper.multiplyDecimal(inner1, step5);
-
+    calcRequiredReincExp: function (data) {
         let residueAdd = mathHelper.addDecimal(mathHelper.createDecimal(data.TotalResidueBD), 1);
         let residueMax = mathHelper.max(
             mathHelper.subtractDecimal(mathHelper.logDecimal(residueAdd, 1.18), 27.82),
@@ -69,11 +56,25 @@ const helper = {
             ),
         );
 
+        return (currLevel) => {
+            let step1 = 5 + currLevel * 5;
+            let temp1 = mathHelper.max(0.0, currLevel / 500000.0);
+            let step2 = mathHelper.min(1.0025, mathHelper.addDecimal(1.00005, temp1));
+            let step3 = mathHelper.min(currLevel, 3000.0);
 
-        let finalStep3 = mathHelper.multiplyDecimal(finalStep2, cowStep);
-        let finalStep4 = mathHelper.multiplyDecimal(finalStep3, expTokenStep);
+            let finalStep1 = mathHelper.multiplyDecimal(step1, mathHelper.pow(step2, step3));
 
-        return finalStep4;
+            let step4Cont = mathHelper.pow(1.001, mathHelper.max(currLevel - 3000, 0.0));
+            let step5 = mathHelper.addDecimal(1, mathHelper.max(0.0, mathHelper.min(1.0, (currLevel - 1500) / 1000)));
+
+            let inner1 = mathHelper.multiplyDecimal(finalStep1, step4Cont);
+            let finalStep2 = mathHelper.multiplyDecimal(inner1, step5);
+
+            let finalStep3 = mathHelper.multiplyDecimal(finalStep2, cowStep);
+            let finalStep4 = mathHelper.multiplyDecimal(finalStep3, expTokenStep);
+
+            return finalStep4;
+        }
     },
 };
 


### PR DESCRIPTION
By pre-calculating and storing the fixed bonuses from cow shop and expedition shop the calculations for each individual level is drastically sped up. Since it tries to calculate the total required reincarnation XP to ascend it does this calculation for possibly hundred of thousands of levels - on each render.

Basic profiling in a browser shows about 40-50% less time spent on page load.