### PR TITLE
Cumulative instant buy view for /protein + Bugfixes

### DIFF
--- a/src/app/protein/AssemblyLine.tsx
+++ b/src/app/protein/AssemblyLine.tsx
@@ -120,7 +120,8 @@ const AssemblyLine = ({
     cost,
     key_inner,
     futureLevel,
-    simplifiedView
+    simplifiedView,
+    bigTopMargin
 }) => {
 
 
@@ -139,7 +140,7 @@ const AssemblyLine = ({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexDirection: 'column',
-                marginTop: index > 1 ? '24px' : '3px',
+                marginTop: index > 1 || !!bigTopMargin ? '24px' : '3px',
                 marginRight: '3px',
                 borderRadius: '6px'
             }}

--- a/src/app/protein/CumulativeAssemblyLine.tsx
+++ b/src/app/protein/CumulativeAssemblyLine.tsx
@@ -1,20 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { BonusMap, dividingBonusArray } from '../util/itemMapping';
 import farmingHelper from '../util/farmingHelper';
-import mathHelper from '../util/math';
 import helper from '../util/helper';
-import useLocalStorage from "use-local-storage";
 
 import rightArrow from '@images/icons/right_arrow_white.svg';
 import lockedAssembly from '@images/farming/assembly/Not_Unlocked.png';
 
 import Image from 'next/image';
-
-//AssemblyCostReductionBonus
-//AssemblerCollection
-
-//Need to manually check if unlocked or not later
 
 const AssemblyInnerBonus = ({ line, al_level, key_inner, futureLevel }) => {
 
@@ -110,29 +103,23 @@ const AssemblyInnerBonus = ({ line, al_level, key_inner, futureLevel }) => {
 
 
 
-
-
-const AssemblyLine = ({
+const CumulativeAssemblyLine = ({
     data,
+    simplifiedView,
     assemblyID,
+    currentLevel,
+    count,
+    totalCost,
     index,
-    purchaseTime,
-    cost,
-    key_inner,
-    futureLevel,
-    simplifiedView
+    futureLevel
 }) => {
-
-
     let assembly = data.AssemblerCollection[assemblyID];
     if (!assembly)
         return null;
 
-    let stringTimeToPurchase = helper.secondsToString(purchaseTime);
-
     return (
         <div
-            key={key_inner}
+            key={assemblyID}
             style={{
                 backgroundColor: 'rgba(255,255,255, 0.12)',
                 display: 'flex',
@@ -157,7 +144,7 @@ const AssemblyLine = ({
                 }}
             >
                 <div style={{ marginLeft: '6px' }}>
-                    Purchase #{index}: Assembly {assemblyID + 1}
+                    Purchase Assembly {assemblyID + 1}
                 </div>
                 <div style={{
                     marginRight: '6px',
@@ -168,13 +155,13 @@ const AssemblyLine = ({
                         {`Level:`}
                     </div>
                     <div
-                        className={(futureLevel - assembly.Level) > 1 ? 'elementToFadeInAndOut' : ''}
+                        className={(futureLevel - currentLevel) > 1 ? 'elementToFadeInAndOut' : ''}
                         style={{
                             marginLeft: '3px',
-                            color: (futureLevel - assembly.Level) > 1 ? 'rgb(66, 174, 41)' : '',
-                            fontWeight: (futureLevel - assembly.Level) > 1 ? 'bold' : ''
+                            color: (futureLevel - currentLevel) > 1 ? 'rgb(66, 174, 41)' : '',
+                            fontWeight: (futureLevel - currentLevel) > 1 ? 'bold' : ''
                         }}>
-                        {`${assembly.Level} -> ${futureLevel}`}
+                        {`${currentLevel} -> ${futureLevel}`}
                     </div>
 
                 </div>
@@ -216,10 +203,10 @@ const AssemblyLine = ({
                 }}
             >
                 <div style={{ marginLeft: '6px' }}>
-                    Cost: {helper.formatNumberString(cost)}
+                    Cost: {helper.formatNumberString(totalCost)}
                 </div>
                 <div style={{ marginRight: '6px' }}>
-                    Time to Purchase: {stringTimeToPurchase}
+                    Purchases: {count}
                 </div>
             </div>
         </div>
@@ -227,4 +214,4 @@ const AssemblyLine = ({
 }
 
 
-export default AssemblyLine;
+export default CumulativeAssemblyLine;

--- a/src/app/util/itemMapping.ts
+++ b/src/app/util/itemMapping.ts
@@ -1033,6 +1033,7 @@ export const BonusMap = {
     5017: { id: 5017, label: "Mineral Type Chance +25%", rootName: 'Mineral Type' },
     5018: { id: 5018, label: "Faster Town Building +25%", rootName: 'Town Building' },
 };
+export const dividingBonusArray = [30,36];
 
 const standardBonusesWeightListCount = Array.from({ length: 22 }, (x, i) => i);
 export const standardBonusesWeightList = standardBonusesWeightListCount.map((idx, i) => BonusMap[i + 1]);


### PR DESCRIPTION
* Added an option to show all the instantly buyable assembly lines in a cumulated view.
* Changed behaviour to always show both the new insta-buy view on the top of the list and the remaining buys below.
* Bugfix wrongly calculated currProtein  when "Use cumulative purchase time" was off.
* Bugfix where dividing bonuses (Building Speed, Contagion HP) where showing 'x' instead of '/'