### PR TITLE
Help text now acknowledges the new splitsaveX option

### DIFF
--- a/src/app/cards/page_content.tsx
+++ b/src/app/cards/page_content.tsx
@@ -390,7 +390,7 @@ const CardCard = ({
                                     Increase: {helper.formatNumberString(mathHelper.multiplyDecimal(percIncrease, 100))}
                                 </div>
                                 <div>
-                                    Weighted Increase: {helper.formatNumberString(weightIncrease)}
+                                    Score: {helper.formatNumberString(loggedWeightIncrease)}
                                 </div>
                                 <div>
                                     Current Weight:{finalWeight}
@@ -568,7 +568,7 @@ const CardCard = ({
                                     Percentage Increase: {helper.formatNumberString(mathHelper.multiplyDecimal(mathHelper.subtractDecimal(percIncrease, 1), 100))}
                                 </div>
                                 <div>
-                                    Weighted Increase: {helper.formatNumberString(weightIncrease)}
+                                    Score: {helper.formatNumberString(loggedWeightIncrease)}
                                 </div>
                                 <div>
                                     Current Weight:{finalWeight}

--- a/src/app/page_content.tsx
+++ b/src/app/page_content.tsx
@@ -213,7 +213,7 @@ export default function Home() {
               <h3 style={{ marginTop: '6px', marginBottom: '12px' }}>Your save file can be found at:</h3>
 
 
-              <div style={{ display: 'flex', marginTop: '12px', marginBottom: '24px' }}>
+              <div style={{ display: 'flex', marginTop: '12px', marginBottom: '12px' }}>
                 <div
                   style={{ fontWeight: 'bold', marginRight: '6px', color: "darkred" }}>
                   All Platforms:
@@ -225,16 +225,27 @@ export default function Home() {
                   {`"copysave"`}
                 </div>
                 <div>
-                  {`in the reward code box (found in settings, gift box icon). If that doesn't work, try doing it in 2 steps->`}
+                  {`in the reward code box (found in settings, gift box icon). If that doesn't work, try doing it in multiple steps:`}
+                </div>
+              </div>
+              <div style={{ display: 'flex', marginTop: '12px', marginBottom: '24px' }}>
+                <div style={{ fontWeight: 'bold', color: "darkred", margin: "0 6px" }}>
+                  {`"splitsave2"`}
+                </div>
+                <div>
+                  {`to split it into 2 parts (number can go up to 1000), then`}
                 </div>
                 <div style={{ fontWeight: 'bold', color: "darkred", margin: "0 6px" }}>
                   {`"copysave1"`}
                 </div>
                 <div>
-                  {`then after that`}
+                  {`and paste into input box, then`}
                 </div>
                 <div style={{ fontWeight: 'bold', color: "darkred", margin: "0 6px" }}>
                   {`"copysave2"`}
+                </div>
+                <div>
+                  {`and paste after it into input box (continue if split into smaller parts), then press the Load button.`}
                 </div>
               </div>
 

--- a/src/app/zones/expedition_focus.tsx
+++ b/src/app/zones/expedition_focus.tsx
@@ -110,6 +110,18 @@ export default function Zones({
             zone.order = zone_data[curr_zone.ID].order;
             zone.bonus_id = zone_data[curr_zone.ID].bonus_id;
             unlocked_ids[zone_data[curr_zone.ID].bonus_id] = zone;
+            if(data.AscensionCount >= 30) {
+                for(let i = 0; i < zone.CardFound.length; i++) {
+                    if(zone.CardFound[i] == 1)
+                        zone.CardFound[i] = 38;
+                }
+            }
+            if(data.AscensionCount >= 40) {
+                for(let i = 0; i < zone.CardFound.length; i++) {
+                    if(zone.CardFound[i] == 3)
+                        zone.CardFound[i] = 39;
+                }
+            }
 
             all_zones.push(zone);
             if (curr_zone.Locked === 0) return;


### PR DESCRIPTION
- The (i) info text on how to acquire the save now mentions the new splitsaveX reward code to split the save file into an arbitrary amount of smaller chunks.
  - As mentioned by asdfchlwnsgy1236 in https://discord.com/channels/481594050999353345/1126557759933010040/1352268722609459231
- Added an edit to the tooltips in /cards to show the score (form loggedWeightedIncrease) instead of the old weighted increase.
- Save file from game has wrong card drops for Munster Desert A30+ and Salmon Lake A40+. Potato/Skull are not properly updated to SWP/SKP. Site now fixes the data manually.