### PR TITLE
speed up /zones

### DIFF
--- a/src/app/zones/expedition_focus.tsx
+++ b/src/app/zones/expedition_focus.tsx
@@ -87,7 +87,7 @@ export default function Zones({
 
 
     let current_zones_stuff = useMemo(() => {
-        console.log(`udating current zone stuff`)
+        console.log(`updating current zone stuff`)
         let current_zones = [];
         let all_zones = [];
         let unlocked_ids = {};
@@ -105,7 +105,11 @@ export default function Zones({
 
             zone.curr_hp = curr_hp;
             zone.max_hp = max_hp;
-            zone.total_hp = calc_total_hp(zone, data, {});
+            if(data.AscensionCount < 14) {
+                zone.total_hp = calc_total_hp(zone, data, {});
+            } else { //Don't calc this all the time after reaching card_focus, since it is unnecessary
+                zone.total_hp = curr_hp;
+            }
             zone.label = zone_data[curr_zone.ID]?.label;
             zone.order = zone_data[curr_zone.ID].order;
             zone.bonus_id = zone_data[curr_zone.ID].bonus_id;

--- a/src/app/zones/page.tsx
+++ b/src/app/zones/page.tsx
@@ -1,4 +1,4 @@
-import Contagion from './page_content';
+import Zones from './page_content';
 
 import Ad_Comp from '../util/ads_component';
 
@@ -17,7 +17,7 @@ export default function Page() {
   return (
     <>
       <Ad_Comp />
-      <Contagion />
+      <Zones />
     </>
   )
 

--- a/src/app/zones/page_content.tsx
+++ b/src/app/zones/page_content.tsx
@@ -277,6 +277,7 @@ export default function Zones() {
     const [clientData, setData] = useLocalStorage('userData', DefaultSave);
     const [data, setRunTimeData] = useState(DefaultSave);
     useEffect(() => {
+        setTargetWave(-1); //reset value to default before loading the actual save file
         setRunTimeData(clientData);
     }, [clientData]);
 

--- a/src/app/zones/zone_lists.ts
+++ b/src/app/zones/zone_lists.ts
@@ -266,7 +266,7 @@ zone_data[24] = {
     img: chocolate_world_img,
     bonus_id: op_level_id,
     order: 24,
-    unlock: 50
+    unlock: -1
 }
 
 
@@ -276,7 +276,7 @@ zone_data[25] = {
     img: butternut_forest_img,
     bonus_id: subclass_id,
     order: 25,
-    unlock: 50
+    unlock: -1
 }
 zone_data[26] = {
     label: 'Strawberry Plain',
@@ -284,7 +284,7 @@ zone_data[26] = {
     img: cheddar_plain_img,
     bonus_id: swp_id,
     order: 26,
-    unlock: 50
+    unlock: -1
 }
 zone_data[27] = {
     label: 'Raspberry Grotto',
@@ -292,7 +292,7 @@ zone_data[27] = {
     img: croissant_castle_img,
     bonus_id: op_minerals_id,
     order: 27,
-    unlock: 50
+    unlock: -1
 }
 zone_data[28] = {
     label: 'Pear Mountain',
@@ -300,7 +300,7 @@ zone_data[28] = {
     img: orange_mountain_img,
     bonus_id: tree_seed_id,
     order: 28,
-    unlock: 50
+    unlock: -1
 }
 zone_data[29] = {
     label: 'Radditz Field',
@@ -308,7 +308,7 @@ zone_data[29] = {
     img: zucchini_field_img,
     bonus_id: skp_id,
     order: 29,
-    unlock: 50
+    unlock: -1
 }
 zone_data[30] = {
     label: 'Lemon Desert',
@@ -316,7 +316,7 @@ zone_data[30] = {
     img: munster_desert_img,
     bonus_id: renown_id,
     order: 30,
-    unlock: 50
+    unlock: -1
 }
 
 
@@ -432,13 +432,12 @@ export const calc_max_hp = function (zone, data, params?) {
 
             console.log(`t: ${t}`)
         }
-        let y = (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025)
-        let z = mathHelper.pow(1.0 + HPIncrease * (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025), Room - 250)
-        let temp = mathHelper.multiplyDecimal(
-            mathHelper.pow(1.0 + HPIncrease, Room - 1),
-
-            mathHelper.pow(1.0 + HPIncrease * (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025), Room - 250)
-        );
+        // let y = (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025)
+        // let z = mathHelper.pow(1.0 + HPIncrease * (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025), Room - 250)
+        // let temp = mathHelper.multiplyDecimal(
+        //     mathHelper.pow(1.0 + HPIncrease, Room - 1),
+        //     mathHelper.pow(1.0 + HPIncrease * (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025), Room - 250)
+        // );
         return (
             mathHelper.multiplyDecimal(
                 mathHelper.addDecimal(

--- a/src/app/zones/zone_lists.ts
+++ b/src/app/zones/zone_lists.ts
@@ -427,11 +427,10 @@ export const calc_max_hp = function (zone, data, params?) {
         );
     }
     if (Room > 250) {
-        let t = mathHelper.pow(1.0 + HPIncrease, Room - 1)
-        if (params?.force_logs) {
-
-            console.log(`t: ${t}`)
-        }
+        // let t = mathHelper.pow(1.0 + HPIncrease, Room - 1)
+        // if (params?.force_logs) {
+        //     console.log(`t: ${t}`)
+        // }
         // let y = (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025)
         // let z = mathHelper.pow(1.0 + HPIncrease * (1.0 - (WAPExpeditionScalingReduced + ExpeShopExpeditionScalingReductionLevel * 2) * 0.0025), Room - 250)
         // let temp = mathHelper.multiplyDecimal(


### PR DESCRIPTION
* The /zones page doesn't calc all the HP values anymore after reaching card focus, since it is not of interest anymore. Individual values for a zone can still be calculated.
* Set zone.unlock value to -1 for zones, which don't need to reach a wave milestone to unlock the next zone